### PR TITLE
return generated unencrypted password so it can be piped into templat…

### DIFF
--- a/library/Network/CloudSeeder/DSL.hs
+++ b/library/Network/CloudSeeder/DSL.hs
@@ -127,7 +127,7 @@ password :: MonadCloud CliError m
   -> Int -- ^ desired password length
   -> T.Text -- ^ output that exports the encryption key
   -> T.Text -- ^ output that exports the bucket where secrets are stored
-  -> CreateT m ()
+  -> CreateT m T.Text
 password path passwordLength encryptionKeyOutput secretsStoreOutput = do
   context <- CreateT ask
   let outputs' = context ^. outputs

--- a/library/Network/CloudSeeder/Interfaces.hs
+++ b/library/Network/CloudSeeder/Interfaces.hs
@@ -315,11 +315,12 @@ upload' bucket path payload = do
     maybe (throwing _CloudErrorInternal "putObject did not return a valid response.")
       return $ return ()
 
-generateEncryptUploadSecret :: MonadCloud e m => Int -> T.Text -> T.Text -> T.Text -> m ()
+generateEncryptUploadSecret :: MonadCloud e m => Int -> T.Text -> T.Text -> T.Text -> m T.Text
 generateEncryptUploadSecret len encryptionKeyId bucket path = do
   secret <- generateSecret len
   encrypted <- encrypt secret encryptionKeyId
   upload bucket path encrypted
+  return secret
 
 instance MonadCloud e m => MonadCloud e (ExceptT e m)
 instance MonadCloud e m => MonadCloud e (LoggingT m)


### PR DESCRIPTION
…es as parameter

lexi: is this a stupid idea? I realize it makes it possible for the password to leak, but I don't see another reasonable way to get the generated passwords into the right parameters, i.e.:
```
stack "db" $ do
  onCreate $ do
      dbpass <- password "authentication-service/as-dbpass" 128 "EncryptionKey" "SecretsStore"
      param "DBMasterUserPassword" dbpass
```